### PR TITLE
Fix workflow badge label casing

### DIFF
--- a/src/lib/github-status.mts
+++ b/src/lib/github-status.mts
@@ -5,7 +5,7 @@ export type WorkflowBadgeState = 'running' | 'success' | 'failure' | 'unknown';
 
 export interface WorkflowBadgeResolved {
   state: WorkflowBadgeState;
-  label: 'Running' | 'success' | 'failure' | 'Unknown';
+  label: 'Running' | 'Success' | 'Failure' | 'Unknown';
 }
 
 export const resolveWorkflowBadge = (
@@ -17,11 +17,11 @@ export const resolveWorkflowBadge = (
   }
 
   if (status === 'completed' && conclusion === 'success') {
-    return { state: 'success', label: 'success' };
+    return { state: 'success', label: 'Success' };
   }
 
   if (status === 'completed' && conclusion === 'failure') {
-    return { state: 'failure', label: 'failure' };
+    return { state: 'failure', label: 'Failure' };
   }
 
   return { state: 'unknown', label: 'Unknown' };

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -470,10 +470,10 @@ const timelineYears = Array.from(
         return { state: 'running', label: 'Running' };
       }
       if (status === 'completed' && conclusion === 'success') {
-        return { state: 'success', label: 'success' };
+        return { state: 'success', label: 'Success' };
       }
       if (status === 'completed' && conclusion === 'failure') {
-        return { state: 'failure', label: 'failure' };
+        return { state: 'failure', label: 'Failure' };
       }
       return { state: 'unknown', label: 'Unknown' };
     };

--- a/tests/unit/github-status.test.mts
+++ b/tests/unit/github-status.test.mts
@@ -16,11 +16,11 @@ describe('resolveWorkflowBadge', () => {
   it('maps completed success and failure', () => {
     expect(resolveWorkflowBadge('completed', 'success')).toEqual({
       state: 'success',
-      label: 'success',
+      label: 'Success',
     });
     expect(resolveWorkflowBadge('completed', 'failure')).toEqual({
       state: 'failure',
-      label: 'failure',
+      label: 'Failure',
     });
   });
 


### PR DESCRIPTION
### Motivation
- Ensure workflow badge labels are presented consistently in the UI by using title case for completed statuses (Success / Failure), avoiding mixed-case text between server- and client-side resolvers.

### Description
- Update `src/lib/github-status.mts` to return `label: 'Success'` and `label: 'Failure'` for completed workflow conclusions.
- Mirror the same casing in the client-side resolver inside `src/pages/index.astro` so dynamically-applied badges match the shared resolver.
- Adjust unit expectations in `tests/unit/github-status.test.mts` to match the new title-case labels.

### Testing
- Ran `npm run test:unit`, and all unit tests passed (3 test files, 7 tests).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989f1a739f0832093a3671dd37acf0f)